### PR TITLE
Makefile.am: Use $(GUILE) for running tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,7 @@ epoll_la_LIBADD = $(GUILE_LIBS)
 epoll_la_LDFLAGS = -export-dynamic -module
 
 TESTS=tests/basic.scm
-TESTS_ENVIRONMENT=top_srcdir="$(abs_top_srcdir)" ./env guile -s
+TESTS_ENVIRONMENT=top_srcdir="$(abs_top_srcdir)" ./env $(GUILE) -s
 
 EXTRA_DIST += \
 	env.in \


### PR DESCRIPTION
I'm assuming you're using guix or something like it -- this just uses $(GUILE) in the makefile so that way I can run with the guile-git package from archlinux. Thanks for making the env script in this project, makes everything else super easy :)