### PR TITLE
Fix #19 by handling EPOLLHUP like EPOLLERR

### DIFF
--- a/fibers/scheduler.scm
+++ b/fibers/scheduler.scm
@@ -185,14 +185,14 @@ remote kernel thread."
      ;; deactivated our entry in the epoll set.
      (set-car! events+waiters #f)
      (set-cdr! events+waiters '())
-     (unless (zero? (logand revents EPOLLERR))
+     (unless (zero? (logand revents (logior EPOLLHUP EPOLLERR)))
        (hashv-remove! (scheduler-fd-waiters sched) fd))
      ;; Now resume or re-schedule waiters, as appropriate.
      (let lp ((waiters waiters))
        (match waiters
          (() #f)
          (((events . task) . waiters)
-          (if (zero? (logand revents (logior events EPOLLERR)))
+          (if (zero? (logand revents (logior events EPOLLHUP EPOLLERR)))
               ;; Re-schedule.
               (schedule-task-when-fd-active sched fd events task)
               ;; Resume.


### PR DESCRIPTION
As civodul pointed out in Issue #19, the EPOLLHUP events are
improperly handled which leads to a epoll_wait/epoll_ctl loop.

From epoll_ctl(2):

  EPOLLERR
    Error condition happened on the associated file descriptor.  This
    event is also reported for the write end of a pipe when the read
    end has been closed.

    epoll_wait(2) will always report for this event; it is not
    necessary to set it in events when calling epoll_ctl().

  EPOLLHUP
    Hang up happened on the associated file descriptor.

    epoll_wait(2) will always wait for this event; it is not necessary
    to set it in events when calling epoll_ctl().

    Note that when reading from a channel such as a pipe or a stream
    socket, this event merely indicates that the peer closed its end
    of the channel.  Subsequent reads from the channel will return
    0 (end of file) only after all outstanding data in the channel has
    been consumed.

To fix this, treat EPOLLHUP identical to EPOLLERR. This should be
fine, as we re-schedule all waiters anyway which ensures that all
outstanding bytes will get read.