### PR TITLE
Fix #33: Scheduler is an optional argument

### DIFF
--- a/fibers.scm
+++ b/fibers.scm
@@ -138,7 +138,7 @@
       (destroy-scheduler scheduler)
       (apply values (atomic-box-ref ret))))))
 
-(define* (spawn-fiber thunk #:optional sched #:key parallel?)
+(define* (spawn-fiber thunk #:optional scheduler #:key parallel?)
   "Spawn a new fiber which will start by invoking @var{thunk}.
 The fiber will be scheduled on the next turn.  @var{thunk} will run
 with a copy of the current dynamic state, isolating fluid and
@@ -151,12 +151,12 @@ parameter mutations to the fiber."
     (schedule-task sched
                    (capture-dynamic-state thunk)))
   (cond
-   (sched
+   (scheduler
     ;; When a scheduler is passed explicitly, it could be there is no
     ;; current fiber; in that case the dynamic state probably doesn't
     ;; have the right right current-read-waiter /
     ;; current-write-waiter, so wrap the thunk.
-    (create-fiber sched
+    (create-fiber scheduler
                   (lambda ()
                     (current-read-waiter wait-for-readable)
                     (current-write-waiter wait-for-writable)

--- a/fibers.texi
+++ b/fibers.texi
@@ -532,8 +532,8 @@ The new fiber will run concurrently with other fibers.
 The fiber will be added to the current scheduler, which is usually
 what you want.  It's also possible to spawn the fiber on a specific
 scheduler, which is useful to ensure that the fiber runs on a
-different kernel thread.  In that case, pass the @code{#:scheduler}
-keyword argument.
+different kernel thread.  In that case, pass the optional
+@code{scheduler} argument.
 
 If @var{parallel?} is true, the fiber will be started not
 (necessarily) on @var{scheduler}, but on a random member of the peer


### PR DESCRIPTION
As #33 points out, scheduler is a optional argument to spawn-fiber,
not a keyword argument.