### PR TITLE
Make work stealing from other schedulers optional

### DIFF
--- a/fibers.texi
+++ b/fibers.texi
@@ -475,7 +475,8 @@ thread, use @code{run-fibers}.
        [#:scheduler=@code{#f}] @
        [#:parallelism=@code{(current-processor-count)}] @
        [#:cpus=@code{(getaffinity 0)}] @
-       [#:hz=@code{100}] [#:drain?=@code{#f}]
+       [#:hz=@code{100}] [#:drain?=@code{#f}] @
+       [#:steal-work?=@code{#t}]
 Run @var{init-thunk} within a fiber in a fresh scheduler, blocking
 until @var{init-thunk} returns.  Return the value(s) returned by the
 call to @var{init-thunk}.
@@ -522,6 +523,11 @@ time).  Note that preemption will only occur if the fiber can actually
 be suspended; @xref{Barriers}, for more information.  Pass @code{0}
 for @var{hz} to disable preemption, effectively making scheduling
 fully cooperative.
+
+By default @var{steal-work?} is @code{#t} which allows schedulers to
+steal work from other schedulers. This can be disabled to ensure
+scheduled tasks only ever get run on the scheduler they were scheduled
+on.
 @end defun
 
 @defun spawn-fiber thunk [scheduler=@code{(require-current-scheduler)}] @
@@ -806,10 +812,11 @@ make.  The resulting schedulers will all share the same prompt tag and
 will steal and share out work from among themselves.
 @end defun
 
-@defun run-scheduler sched finished?
+@defun run-scheduler sched finished? [steal-work?=@code{#t}]
 Run @var{sched} until calling the supplied @var{finished?} thunk
-returns true.  Return zero values.  Signal an error if @var{scheduler}
-is already running in some other kernel thread.
+returns true.  If @code{steal-work?} is true, enable work stealing
+from remote peers.  Return zero values.  Signal an error if
+@var{scheduler} is already running in some other kernel thread.
 @end defun
 
 @defun current-scheduler

--- a/fibers/scheduler.scm
+++ b/fibers/scheduler.scm
@@ -260,9 +260,10 @@ any pending timeouts."
             (stack-empty? (scheduler-current-runqueue sched))
             (stack-empty? (scheduler-next-runqueue sched)))))
 
-(define* (run-scheduler sched finished?)
+(define* (run-scheduler sched finished? #:optional (steal-work? #t))
   "Run @var{sched} until calling @code{finished?} returns a true
-value.  Return zero values."
+value.  If @code{steal-work?} is true, enable work stealing from
+remote peers. Return zero values."
   (let ((tag (scheduler-prompt-tag sched))
         (runcount-box (scheduler-runcount-box sched))
         (next (scheduler-next-runqueue sched))
@@ -278,7 +279,7 @@ value.  Return zero values."
     (define (next-task)
       (match (stack-pop! cur #f)
         (#f
-         (when (stack-empty? next)
+         (when (and steal-work? (stack-empty? next))
            ;; Both current and next runqueues are empty; steal a
            ;; little bit of work from a remote scheduler if we
            ;; can.  Run it directly instead of pushing onto a


### PR DESCRIPTION
When working with multiple fibers and ports, disabling work-stealing
makes it easier to ensure only one thread is accessing a given port.
E.g. this allows a fiber to spawn additional fibers to access a port
without running into issues.