### PR TITLE
texi: un-comment indices.

### DIFF
--- a/fibers.texi
+++ b/fibers.texi
@@ -53,7 +53,7 @@ Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 * Examples::              Starting points for a hack.
 * Status::                Fibers is a work in progress.
 
-* Index::                 Index of concepts and procedures.
+* Index::                 Index of procedures.
 @end menu
 
 @end ifnottex
@@ -1425,9 +1425,6 @@ up to you.  Happy hacking and godspeed!
 
 @node Index
 @unnumbered Index
-@printindex cp
-@syncodeindex tp fn
-@syncodeindex vr fn
 @printindex fn
 
 @bye


### PR DESCRIPTION
I see no reason for not rendering the index that already is there.

The concept index is currently also empty, but I enabled it to in case something gets added to it later.