### PR TITLE
Eliminate FIBERS_CROSS_COMPILING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,7 @@ build/
 /fibers.info
 /fibers/affinity.scm
 /fibers/config.scm
-/fibers/posix-clocks.scm
-/fibers/events-impl.scm
+/override
 *.la
 *.lo
 *.go

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (C) 2016 Andy Wingo <wingo@pobox.com>
 # Copyright (C) 2020 Abdulrahman Semrie <hsamireh@gmail.com>
 # Copyright (C) 2020-2022 Aleix Conchillo Flaqué <aconchillo@gmail.com>
+# Copyright (C) 2023 Maxime Devos <maximedevos@telenet.be>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -26,6 +27,10 @@ godir=$(libdir)/guile/$(GUILE_EFFECTIVE_VERSION)/site-ccache
 
 info_TEXINFOS=fibers.texi
 
+# Don't include fibers/events-impl.scm in here even though it's a source file,
+# otherwise "make install" will install fibers/events-impl.scm even though
+# shouldn't.  Likewise for fibers/posix-clocks.scm.
+
 SOURCES = \
 	fibers.scm \
 	fibers/affinity.scm \
@@ -33,13 +38,11 @@ SOURCES = \
 	fibers/conditions.scm \
 	fibers/config.scm \
 	fibers/counter.scm \
-	fibers/events-impl.scm \
 	fibers/deque.scm \
 	fibers/interrupts.scm \
 	fibers/io-wakeup.scm \
 	fibers/nameset.scm \
 	fibers/operations.scm \
-	fibers/posix-clocks.scm \
 	fibers/psq.scm \
 	fibers/repl.scm \
 	fibers/scheduler.scm \
@@ -50,8 +53,8 @@ SOURCES = \
 
 BUILT_SOURCES = \
 	fibers/config.scm \
-	fibers/events-impl.scm \
-	fibers/posix-clocks.scm
+	override/fibers/events-impl.scm \
+	override/fibers/posix-clocks.scm
 
 extlibdir = $(libdir)/guile/$(GUILE_EFFECTIVE_VERSION)/extensions
 AM_CFLAGS = -I$(srcdir) $(WARN_CFLAGS) $(DEBUG_CFLAGS)
@@ -65,8 +68,9 @@ fibers_libevent_la_CFLAGS = $(AM_CFLAGS) $(GUILE_CFLAGS) $(LIBEVENT_CFLAGS) -I$(
 fibers_libevent_la_LDFLAGS = -module -no-undefined $(LIBEVENT_LIBS) $(GUILE_LDFLAGS)
 $(GOBJECTS): fibers-libevent.la
 
-fibers/events-impl.scm: Makefile fibers/libevent.scm
-	cp -f $(abs_top_srcdir)/fibers/libevent.scm $(abs_top_builddir)/fibers/events-impl.scm
+override/fibers/events-impl.scm: Makefile fibers/libevent.scm
+	mkdir -p $(abs_top_builddir)/override/fibers
+	cp -f $(abs_top_srcdir)/fibers/libevent.scm $(abs_top_builddir)/override/fibers/events-impl.scm
 else
 if HAVE_EPOLL_WAIT
 extlib_LTLIBRARIES += fibers-epoll.la
@@ -76,8 +80,9 @@ fibers_epoll_la_LIBADD = $(GUILE_LIBS)
 fibers_epoll_la_LDFLAGS = -export-dynamic -module
 $(GOBJECTS): fibers-epoll.la
 
-fibers/events-impl.scm: Makefile fibers/epoll.scm
-	cp -f $(abs_top_srcdir)/fibers/epoll.scm $(abs_top_builddir)/fibers/events-impl.scm
+override/fibers/events-impl.scm: Makefile fibers/epoll.scm
+	mkdir -p $(abs_top_builddir)/override/fibers
+	cp -f $(abs_top_srcdir)/fibers/epoll.scm $(abs_top_builddir)/override/fibers/events-impl.scm
 endif
 endif
 
@@ -93,14 +98,16 @@ fibers/config.scm: Makefile fibers/config.scm.in
 	sed -e "s|@extlibdir\@|$(extlibdir)|" \
 	    $(srcdir)/fibers/config.scm.in > fibers/config.scm
 
-fibers/posix-clocks.scm: Makefile fibers/posix-clocks-$(PLATFORM).scm
-	mkdir -p $(abs_top_builddir)/fibers
-	cp -f $(abs_top_srcdir)/fibers/posix-clocks-$(PLATFORM).scm $(abs_top_builddir)/fibers/posix-clocks.scm
+override/fibers/posix-clocks.scm: Makefile fibers/posix-clocks-$(PLATFORM).scm
+	mkdir -p $(abs_top_builddir)/override/fibers
+	cp -f $(abs_top_srcdir)/fibers/posix-clocks-$(PLATFORM).scm $(abs_top_builddir)/override/fibers/posix-clocks.scm
 
 CLEANFILES += \
 	fibers/config.scm \
-	fibers/events-impl.scm \
-	fibers/posix-clocks.scm
+	override/fibers/events-impl.go \
+	override/fibers/posix-clocks.go \
+	override/fibers/events-impl.scm \
+	override/fibers/posix-clocks.scm
 
 TESTS = \
 	tests/basic.scm \
@@ -131,8 +138,10 @@ EXTRA_DIST += \
 	README.md \
 	TODO.md \
 	fibers/config.scm.in \
+	fibers/events-impl.scm \
 	fibers/epoll.scm \
 	fibers/libevent.scm \
+	fibers/posix-clocks.scm \
 	fibers/posix-clocks-darwin.scm \
 	fibers/posix-clocks-generic.scm \
 	examples

--- a/build-aux/guile.am
+++ b/build-aux/guile.am
@@ -1,13 +1,14 @@
-if CROSS_COMPILING
-CROSS_COMPILING_VARIABLE = FIBERS_CROSS_COMPILING=yes
-else
-CROSS_COMPILING_VARIABLE =
-endif
-
 GOBJECTS = $(SOURCES:%.scm=%.go)
 
 nobase_mod_DATA = $(SOURCES) $(NOCOMP_SOURCES)
 nobase_go_DATA = $(GOBJECTS)
+
+# This is like adding the files to moddir and godir directly, except for
+# dropping the 'override' prefix that is only needed for cross-compilation.
+fibersdir = $(moddir)/fibers
+gofibersdir = $(godir)/fibers
+nodist_fibers_DATA = override/fibers/events-impl.scm override/fibers/posix-clocks.scm
+nodist_gofibers_DATA = override/fibers/events-impl.go override/fibers/posix-clocks.go
 
 # Make sure source files are installed first, so that the mtime of
 # installed compiled files is greater than that of installed source
@@ -22,6 +23,6 @@ EXTRA_DIST = $(SOURCES) $(NOCOMP_SOURCES)
 GUILE_WARNINGS = -Wunbound-variable -Warity-mismatch -Wformat
 SUFFIXES = .scm .go
 .scm.go:
-	$(AM_V_GEN)$(CROSS_COMPILING_VARIABLE) $(top_builddir)/env	\
+	$(AM_V_GEN) $(top_builddir)/env	\
 	  $(GUILE_TOOLS) compile $(GUILE_TARGET) -L "$(abs_top_srcdir)"	\
 	  $(GUILE_WARNINGS) -o "$@" "$<"

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ License along with this program.  If not, see
 
 ]])
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 AC_INIT([fibers],[1.2.0])
 AC_CONFIG_SRCDIR([env.in])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/env.in
+++ b/env.in
@@ -2,6 +2,7 @@
 
 # fibers
 # Copyright (C) 2016  Andy Wingo <wingo@pobox.com>
+# Copyright (C) 2023 Maxime Devos <maximedevos@telenet.be>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -27,10 +28,12 @@ if test "@abs_top_srcdir@" != "@abs_top_builddir@"; then
   GUILE_LOAD_PATH=@abs_top_builddir@:$GUILE_LOAD_PATH
 fi
 
+GUILE_LOAD_PATH=@abs_top_builddir@/override:$GUILE_LOAD_PATH
+
 if test "$GUILE_LOAD_COMPILED_PATH" = ""; then
-  GUILE_LOAD_COMPILED_PATH=@abs_top_builddir@
+  GUILE_LOAD_COMPILED_PATH=@abs_top_builddir@/override:@abs_top_builddir@
 else
-  GUILE_LOAD_COMPILED_PATH=@abs_top_builddir@:$GUILE_LOAD_COMPILED_PATH
+  GUILE_LOAD_COMPILED_PATH=@abs_top_builddir@/override:$GUILE_LOAD_COMPILED_PATH
 fi
 
 if test "$GUILE_EXTENSIONS_PATH" = ""; then

--- a/fibers/epoll.scm
+++ b/fibers/epoll.scm
@@ -37,12 +37,8 @@
 
             EVENTS_IMPL_READ EVENTS_IMPL_WRITE EVENTS_IMPL_CLOSED_OR_ERROR))
 
-(eval-when (eval load compile)
-  ;; When cross-compiling, the cross-compiled 'fibers-epoll.so' cannot be loaded
-  ;; by the 'guild compile' process; skip it.
-  (unless (getenv "FIBERS_CROSS_COMPILING")
-    (dynamic-call "init_fibers_epoll"
-                  (dynamic-link (extension-library "fibers-epoll")))))
+(dynamic-call "init_fibers_epoll"
+              (dynamic-link (extension-library "fibers-epoll")))
 
 (when (defined? 'EPOLLRDHUP)
   (export EPOLLRDHUP))

--- a/fibers/events-impl.scm
+++ b/fibers/events-impl.scm
@@ -1,0 +1,43 @@
+;;;; Copyright (C) 2023 Maxime Devos <maximedevos@telenet.be>
+;;;;
+;;;; This library is free software; you can redistribute it and/or
+;;;; modify it under the terms of the GNU Lesser General Public
+;;;; License as published by the Free Software Foundation; either
+;;;; version 3 of the License, or (at your option) any later version.
+;;;;
+;;;; This library is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;;;; Lesser General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU Lesser General Public License
+;;;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;;;
+
+(define-module (fibers events-impl)
+  #:export (events-impl-create
+	    events-impl-destroy
+	    events-impl?
+	    events-impl-add!
+	    events-impl-wake!
+	    events-impl-fd-finalizer
+	    events-impl-run
+
+	    EVENTS_IMPL_READ EVENTS_IMPL_WRITE EVENTS_IMPL_CLOSED_OR_ERROR))
+
+;; When cross-compiling, the cross-compiled 'fibers-libevent.so' cannot be loaded
+;; by the 'guild compile' process, so during the compilation of Guile-Fibers
+;; this 'fake' fibers/events-impl.scm / fibers/events-impl.go module is loaded,
+;; which doesn't link to the library.
+;; Likewise for other libraries (e.g. fibers-epoll.so).
+;;
+;; When Guile-Fibers is actually installed, the real fibers/epoll.scm or
+;; fibers/libevents.scm and their corresponding .go is installed instead.
+;; Likewise, when tests are run, the real modules are used instead.
+;;
+;; In the past, a FIBERS_CROSS_COMPILING environment variable was consulted
+;; at runtime.  However, this is problematic in some situations.  For example,
+;; when using './env', the user might want to start a program that
+;; (as an implementation detail) happens to use Guile-Fibers and hence needs
+;; to load the relevant ".so" of the copy of Guile-Fibers of that program,
+;; which FIBERS_CROSS_COMPILING would prevent.

--- a/fibers/libevent.scm
+++ b/fibers/libevent.scm
@@ -37,13 +37,8 @@
 
               EVENTS_IMPL_READ EVENTS_IMPL_WRITE EVENTS_IMPL_CLOSED_OR_ERROR))
 
-(eval-when (eval load compile)
-  ;; When cross-compiling, the cross-compiled 'fibers-libevent.so' cannot be
-  ;; loaded by the 'guild compile' process; skip it.
-  (unless (getenv "FIBERS_CROSS_COMPILING")
-    (dynamic-call "init_fibers_libevt"
-                  (dynamic-link (extension-library "fibers-libevent")))))
-
+(dynamic-call "init_fibers_libevt"
+              (dynamic-link (extension-library "fibers-libevent")))
 
 (define (make-wake-pipe)
   (define (set-nonblocking! port)

--- a/fibers/posix-clocks-darwin.scm
+++ b/fibers/posix-clocks-darwin.scm
@@ -30,12 +30,7 @@
 
 (define exe (dynamic-link))
 
-(define exe-clocks
-  (eval-when (eval load compile)
-    ;; When cross-compiling, the cross-compiled 'fibers-clocks.so' cannot
-    ;; be loaded by the 'guild compile' process; skip it.
-    (unless (getenv "FIBERS_CROSS_COMPILING")
-      (dynamic-link (extension-library "fibers-clocks")))))
+(dynamic-link (extension-library "fibers-clocks"))
 
 (define clockid-t int32)
 (define time-t long)

--- a/fibers/posix-clocks.scm
+++ b/fibers/posix-clocks.scm
@@ -1,0 +1,22 @@
+;;;; Copyright (C) 2023 Maxime Devos <maximedevos@telenet.be>
+;;;;
+;;;; This library is free software; you can redistribute it and/or
+;;;; modify it under the terms of the GNU Lesser General Public
+;;;; License as published by the Free Software Foundation; either
+;;;; version 3 of the License, or (at your option) any later version.
+;;;;
+;;;; This library is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;;;; Lesser General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU Lesser General Public License
+;;;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;;;
+
+(define-module (fibers posix-clocks)
+  #:export (clock-nanosleep
+            pthread-getcpuclockid
+            pthread-self))
+
+;; This module is left for the same reason as for events-impl.scm.


### PR DESCRIPTION
This avoids a potential cross-compilation issue, see the rationale in fibers/events-impl.scm