### PR TITLE
fix: avoid deprecation warnings for bit-vector functions

### DIFF
--- a/fibers.scm
+++ b/fibers.scm
@@ -35,28 +35,22 @@
 ;; Guile 2 and 3 compatibility. Some bit vector related procedures were
 ;; deprecated in Guile 3.0.3 and new ones were defined.
 (define bitvector-count*
-  (cond-expand
-   (guile-3
-    (if (defined? 'bitvector-count)
-        bitvector-count
-        (lambda (v) (bit-count #t v))))
-   (guile-2 (lambda (v) (bit-count #t v)))))
+  (or (and=> (module-variable the-scm-module 'bitvector-count)
+             variable-ref)
+      (lambda (v)
+        (bit-count #t v))))
 
 (define bitvector-position*
-  (cond-expand
-   (guile-3
-    (if (defined? 'bitvector-position)
-        bitvector-position
-        (lambda (v b i) (bit-position b v i))))
-   (guile-2 (lambda (v b i) (bit-position b v i)))))
+  (or (and=> (module-variable the-scm-module 'bitvector-position)
+             variable-ref)
+      (lambda (v b i)
+        (bit-position b v i))))
 
 (define bitvector-set-bit!*
-  (cond-expand
-   (guile-3
-    (if (defined? 'bitvector-set-bit!)
-        bitvector-set-bit!
-        (lambda (v i) (bitvector-set! v i #t))))
-   (guile-2 (lambda (v i) (bitvector-set! v i #t)))))
+  (or (and=> (module-variable the-scm-module 'bitvector-set-bit!)
+             variable-ref)
+      (lambda (v i)
+        (bitvector-set! v i #t))))
 ;; End of Guile 2 and 3 compatibility.
 
 (define (wait-for-readable port)


### PR DESCRIPTION
this should fix https://github.com/wingo/fibers/issues/79

it's based on @civodul's recommended way of resolving it. (thanks!)

the `guile-fibers` Guix package builds fine with this commit, including the tests.

note: i still see one warning when i'm running a `guix system vm` with a custom `shepherd` as PID 1, that uses a custom `guile-fibers` with this commit. i hope that it's due to my failure to fully understand the Guix machinery, and not that the deprecation warning still gets triggered even with this commit included.

@civodul i would appreciate if you could test this PR in the above environment while you're working on shepherd, or just take a look and point out any issues that you spot.