### PR TITLE
scheduler: Set a simple custom record printer.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Next version
 * Implement new constructrs 'make-read-waiter' and 'make-write-waiter'
   and related procedures to aid in defining new operations on ports.
 * Implement a new operation 'accept-operation' corresponding to 'accept'.
+* Printing scheduler objects is now way less verbose.
 
 fibers 1.3.1 -- 2023-05-30
 ==========================

--- a/NEWS
+++ b/NEWS
@@ -2,11 +2,14 @@ Fibers NEWS
 
 Fibers is a facility that provides Go-like concurrency for Guile Scheme.
 
-next version
+Next version
 ============
 
 * New procedure 'dynamic-wind*' that behaves like 'dynamic-wind' except
   for interacting nicely with rescheduling.
+* Implement new constructrs 'make-read-waiter' and 'make-write-waiter'
+  and related procedures to aid in defining new operations on ports.
+* Implement a new operation 'accept-operation' corresponding to 'accept'.
 
 fibers 1.3.1 -- 2023-05-30
 ==========================

--- a/fibers.texi
+++ b/fibers.texi
@@ -54,7 +54,7 @@ Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 * Examples::              Starting points for a hack.
 * Status::                Fibers is a work in progress.
 
-* Index::                 Index of concepts and procedures.
+* Index::                 Index of procedures.
 @end menu
 
 @end ifnottex
@@ -1573,9 +1573,6 @@ up to you.  Happy hacking and godspeed!
 
 @node Index
 @unnumbered Index
-@printindex cp
-@syncodeindex tp fn
-@syncodeindex vr fn
 @printindex fn
 
 @bye

--- a/fibers.texi
+++ b/fibers.texi
@@ -5,15 +5,16 @@
 @c %**end of header
 
 @set VERSION 1.3.1
-@set UPDATED 30 May 2023
+@set UPDATED 22 August 2023
 
 @copying
 This manual is for Fibers (version @value{VERSION}, updated
 @value{UPDATED})
 
 @noindent
-Copyright 2016-2023 Andy Wingo
-Copyright 2021, 2023 Maxime Devos
+Copyright 2016-2023 Andy Wingo@*
+Copyright 2021, 2023 Maxime Devos@*
+Copyright 2021, 2023 Maxime Devos@*
 Copyright 2022, 2023 Aleix Conchillo Flaqué
 
 @quotation
@@ -751,6 +752,95 @@ succeeds when a connection becomes available.
 @defun wait-until-port-writable-operation port
 Make an operation that will succeed with no values when the output
 port @var{port} becomes writable.
+@end defun
+
+Usually, you don't only want to detect readiness, but also act upon
+it. While this can be accomplished by combining one of the previous
+two procedures with @code{wrap-operation}, the spurious wake-ups can
+be inconvenient. In that case, the following two procedures may be
+useful:
+
+@defun make-read-operation try-fn port
+Make an operation that tries @var{try-fn}, and when @var{try-fn}
+fails, blocks until @var{port} is readable.  @var{try} is a thunk that
+either returns @code{#false}, indicating failure, or a thunk, whose
+return values are the result of the operation.
+@end defun
+
+@defun make-write-operation try-fn port
+Make an operation that tries @var{try-fn}, and when @var{try-fn}
+fails, blocks until @var{port} is writable.  @var{try} is a thunk that
+either returns @code{#false}, indicating failure, or a thunk, whose
+return values are the result of the operation.
+@end defun
+
+Often, failure is indicated by a procedure calling the thunk of
+@code{current-read-waiter} or @code{current-write-waiter}.  In that
+case, the following two procedures can be useful:
+
+@defun with-read-waiting-is-failure port try-fn
+Return a thunk like @var{try-fn}, except that it also fails when
+@var{try-fn} the procedure from the parameter
+@code{current-write-waiter} is invoked on @var{port}.
+
+The read waiter at the current depth (relative to the invocation of
+the returned thunk) may not be changed while the thunk is being invoked.
+@end defun
+
+@defun with-write-waiting-is-failure port try-fn
+Return a thunk like @var{try-fn}, except that it also fails when
+@var{try-fn} the procedure from the parameter
+@code{current-write-waiter} is invoked on @var{port}.
+
+The write waiter at the current depth (relative to the invocation of
+the returned thunk) may not be changed while the thunk is being invoked.
+@end defun
+
+These two procedures need to install a new read/write waiter, but this
+waiter doesn't cover all situations and as such might need to call the
+‘previous’ waiter in turn.  The waiter has two options for accessing
+the previous waiter:
+
+@itemize
+@item the constructed thunk could save the at the time current waiter
+(this is what's done currently)
+@item the read waiter could look ‘deeper’ in the fluid stack by using
+@code{fluid-ref*}
+@end itemize
+
+The first option also has a problem: if prompts are used, it is
+possible that the ‘less deep’ waiter changes after the old ‘less deep’
+waiter was saved.
+
+The second option would be ideal, but the problem is that the waiter
+doesn't know how deep it is in the stack -- while it could iterate the
+fluid stack and use @code{eq?} what depths are possible, it might
+exist at multiple depths at the same time even though the waiter is
+‘fresh’ because of weird usage of prompts.
+
+Perhaps the solution is to add a ‘depth’ argument to the procedures of
+@code{current-read-waiter} and @code{current-write-waiter} or allow
+the waiter to return true or false to indicate whether it handled the
+situation or whether the previous waiter should be tried, but neither
+of these is implemented yet at time of writing.
+
+In the meantime, don't change the ‘less deep’ waiter while
+@code{with-read-waiter} / @code{with-write-waiter} is doing its thing!
+
+@defun accept-operation port [flags=(logior O_NONBLOCK O_CLOEXEC)]
+Like @code{(accept port flags)}, but as an operation.  Unlike
+@code{accept}, @code{O_NONBLOCK} is included in the default flags,
+which makes the accepted port non-blocking and hence suitable for
+use with Fibers.
+
+The flag @code{O_CLOEXEC} is also included (if available).  Without
+this flag, ports would be leaked to subprocesses by default, which
+usually is at best inefficient and at worst a security problem.  But
+rarely, ports are intended to be leaked to subprocesses, in which
+case you could remove this flag.
+
+Fibers doesn't emulate @code{O_CLOEXEC} when unavailable, because it
+would not be entirely equivalent in case of parallelism.
 @end defun
 
 @node REPL Commands

--- a/fibers.texi
+++ b/fibers.texi
@@ -14,7 +14,6 @@ This manual is for Fibers (version @value{VERSION}, updated
 @noindent
 Copyright 2016-2023 Andy Wingo@*
 Copyright 2021, 2023 Maxime Devos@*
-Copyright 2021, 2023 Maxime Devos@*
 Copyright 2022, 2023 Aleix Conchillo Flaqué
 
 @quotation

--- a/fibers.texi
+++ b/fibers.texi
@@ -282,7 +282,7 @@ is the main idea of a CSP-derived system called ``Concurrent ML''
 New Jersey by John Reppy, CML provides this abstraction, which in
 Fibers is called an @dfn{operation}@footnote{CML uses the term
 @dfn{event}, but we find this to be a confusing name.}.  Calling
-@code{send-operation} on a channel returns an operation, which is just
+@code{put-operation} on a channel returns an operation, which is just
 a value.  Operations are like closures in a way; a closure wraps up
 code in its environment, which can be later called many times or not
 at all.  Operations likewise can be @dfn{performed}@footnote{In CML,

--- a/fibers/io-wakeup.scm
+++ b/fibers/io-wakeup.scm
@@ -1,7 +1,7 @@
 ;; Fibers: cooperative, event-driven user-space threads.
 
 ;;;; Copyright (C) 2016,2021 Free Software Foundation, Inc.
-;;;; Copyright (C) 2021 Maxime Devos
+;;;; Copyright (C) 2021,2023 Maxime Devos
 ;;;;
 ;;;; This library is free software; you can redistribute it and/or
 ;;;; modify it under the terms of the GNU Lesser General Public
@@ -21,11 +21,18 @@
   #:use-module (fibers scheduler)
   #:use-module (fibers operations)
   #:use-module (ice-9 atomic)
+  #:use-module (ice-9 control)
   #:use-module (ice-9 match)
+  #:use-module (ice-9 suspendable-ports)
   #:use-module (ice-9 threads)
   #:use-module (ice-9 ports internal)
-  #:export (wait-until-port-readable-operation
-	    wait-until-port-writable-operation))
+  #:export (make-read-operation
+	    make-write-operation
+	    wait-until-port-readable-operation
+	    wait-until-port-writable-operation
+	    accept-operation
+	    with-read-waiting-is-failure
+	    with-write-waiting-is-failure))
 
 (define *poll-sched* (make-atomic-box #f))
 
@@ -56,37 +63,119 @@
     ((#() #() #()) #f)
     ((#() #(_) #()) #t)))
 
-(define (make-wait-operation ready? schedule-when-ready port port-ready-fd this-procedure)
-  (make-base-operation #f
-                       (lambda _
-                         (and (ready? port) values))
-                       (lambda (flag sched resume)
-                         (define (commit)
-                           (match (atomic-box-compare-and-swap! flag 'W 'S)
-                             ('W (resume values))
-                             ('C (commit))
-                             ('S #f)))
-                         (if sched
-                             (schedule-when-ready
-                              sched (port-ready-fd port) commit)
-                             (schedule-task
-                              (poll-sched)
-                              (lambda ()
-                                (perform-operation (this-procedure port))
-                                (commit)))))))
+(define (try-ready ready? port)
+  (lambda ()
+    (and (ready? port) values)))
+
+(define (make-wait-operation try-fn schedule-when-ready port port-ready-fd)
+  (letrec ((this-operation
+	    (make-base-operation
+	     #f
+	     try-fn
+	     (lambda (flag sched resume)
+	       (define (commit)
+		 (match (atomic-box-compare-and-swap! flag 'W 'S)
+			('W (resume values))
+			('C (commit))
+			('S #f)))
+	       (if sched
+		   (schedule-when-ready
+		    sched (port-ready-fd port) commit)
+		   (schedule-task
+		    (poll-sched)
+		    (lambda ()
+		      (perform-operation this-operation)
+		      (commit))))))))
+    this-operation))
+
+(define (make-read-operation try-fn port)
+  "Make an operation that tries TRY-FN, and when TRY-FN fails, blocks until
+the input port PORT is readable.  TRY-FN is a thunk that either returns #false,
+indicating failure, or a thunk, whose return values are the result of the
+operation."
+  (unless (input-port? port)
+    (error "refusing to wait forever for input on non-input port"))
+  (make-wait-operation try-fn schedule-task-when-fd-readable port
+		       port-read-wait-fd))
+
+(define (make-write-operation try-fn port)
+  "Make an operation that tries TRY-FN, and when TRY-FN fails, blocks until
+the output PORT is writable.  TRY-FN is a thunk that either returns #false,
+indicating failure, or a thunk, whose return values are the result
+of the operation."
+  (unless (output-port? port)
+    (error "refusing to wait forever for output on non-output port"))
+  (make-wait-operation try-fn schedule-task-when-fd-writable port
+		       port-write-wait-fd))
 
 (define (wait-until-port-readable-operation port)
   "Make an operation that will succeed when PORT is readable."
-  (unless (input-port? port)
-    (error "refusing to wait forever for input on non-input port"))
-  (make-wait-operation readable? schedule-task-when-fd-readable port
-                       port-read-wait-fd
-                       wait-until-port-readable-operation))
+  (make-read-operation (try-ready readable? port) port))
 
 (define (wait-until-port-writable-operation port)
   "Make an operation that will succeed when PORT is writable."
-  (unless (output-port? port)
-    (error "refusing to wait forever for output on non-output port"))
-  (make-wait-operation writable? schedule-task-when-fd-writable port
-                       port-write-wait-fd
-                       wait-until-port-writable-operation))
+  (make-write-operation (try-ready readable? port) port))
+
+(define (with-x-waiting-is-failure port current-x-waiter try-fn)
+  "Return a thunk like TRY-FN, except that it also fails when
+TRY-FN invokes the procedure from the parameter CURRENT-X-WAITER on PORT.
+CURRENT-X-WAITER is a parameter like current-read-waiter or
+current-write-waiter.
+
+Due to technical limitations of current-read-waiter/current-write-waiter,
+TRY-FN may not modify CURRENT-X-WAITER in ways that this procedure might
+notice."
+  (lambda ()
+    (let/ec escape
+      (let* ((old-waiter (current-x-waiter))
+	     (new-waiter
+	      (lambda (port*)
+		(if (eq? port port*)
+		    (escape #false)
+		    ;; Maybe TRY-FN is doing some logging?  Whatever is
+		    ;; happening, (fibers io-wakeup) shouldn't interfere.
+		    (old-waiter port*)))))
+	(parameterize ((current-x-waiter new-waiter))
+	  (try-fn))))))
+
+(define (with-read-waiting-is-failure port try-fn)
+  "Return a thunk like TRY-FN, except that it also fails when TRY-FN
+invokes the procedure from the parameter current-read-waiter on PORT.
+
+The read waiter at the current depth (relative to the invocation of
+the returned thunk) may not be changed while the thunk is being invoked."
+  (with-x-waiting-is-failure port current-read-waiter try-fn))
+
+(define (with-write-waiting-is-failure port try-fn)
+  "Return a thunk like TRY-FN, except that it also fails when TRY-FN
+invokes the procedure from the parameter current-write-waiter on PORT.
+
+The write waiter at the current depth (relative to the invocation of
+the returned thunk) may not be changed while the thunk is being invoked."
+  (with-x-waiting-is-failure port current-write-waiter try-fn))
+
+(define O_CLOEXEC*
+  (if (defined? 'O_CLOEXEC)
+      O_CLOEXEC ; doesn't exist on guile-2.2
+      0))
+
+(define* (accept-operation port #:key (flags (logior O_CLOEXEC* O_NONBLOCK)))
+  "Like '(accept port flags)', but as an operation.  Unlike
+'accept', 'O_NONBLOCK' is included in the default flags,
+which makes the accepted port non-blocking and hence suitable for
+use with Fibers.
+
+The flag 'O_CLOEXEC' is also included (if available).  Without
+this flag, ports would be leaked to subprocesses by default, which
+usually is at best inefficient and at worst a security problem.  But
+rarely, ports are intended to be leaked to subprocesses, in which
+case you could remove this flag.
+
+Fibers doesn't emulate 'O_CLOEXEC' when unavailable, because it
+would not be entirely equivalent in case of parallelism."
+  (define (try)
+    (let ((new (accept port flags)))
+      (and new (lambda () (values new)))))
+  (make-read-operation
+   (with-read-waiting-is-failure port try)
+   port))

--- a/fibers/scheduler.scm
+++ b/fibers/scheduler.scm
@@ -284,6 +284,8 @@ value.  Return zero values."
         (cur (scheduler-current-runqueue sched))
         (steal-work! (work-stealer sched)))
     (define (run-task task)
+      ;; The only thread writing to the runcount box is the thread of SCHED,
+      ;; so no need for atomic-box-compare-and-swap! here.
       (atomic-box-set! runcount-box
                        (logand (1+ (atomic-box-ref runcount-box)) #xffffFFFF))
       (call-with-prompt tag


### PR DESCRIPTION
The default record printer in Guile seems to produce a large (maybe infinite) output for schedulers, so this simple record printer prevents that.