### PR TITLE
Stop reading the request body in the fibers web server

### DIFF
--- a/examples/concurrent-web-hello.scm
+++ b/examples/concurrent-web-hello.scm
@@ -1,7 +1,9 @@
-(use-modules (fibers web server))
+(use-modules (http request)
+             (fibers web server))
 
-(define (handler request body)
-  (values '((content-type . (text/plain)))
-          "Hello, World!"))
+(define (handler request)
+  (let ((body (read-request-body request)))
+    (values '((content-type . (text/plain)))
+            "Hello, World!")))
 
 (run-server handler)

--- a/fibers.texi
+++ b/fibers.texi
@@ -1396,11 +1396,13 @@ run a standalone web server, use the @code{(fibers web server)}
 module:
 
 @example
-(use-modules (fibers web server))
+(use-modules (http request)
+             (fibers web server))
 
-(define (handler request body)
-  (values '((content-type . (text/plain)))
-          "Hello, World!"))
+(define (handler request)
+  (let ((body (read-request-body request)))
+    (values '((content-type . (text/plain)))
+            "Hello, World!")))
 
 (run-server handler)
 @end example


### PR DESCRIPTION
This is a rather out there suggestion of a breaking change to the (fibers web server). I want to be able to handle large file uploads (several GB) and don't want that several GB of data to sit in memory while the request is being processed.

Instead, the handler must read the request body if there is one to read.

The intention here is to make it possible to process the request body in different ways. For example, use a chunked input port if it's chunked, or maybe just write it to disk without first reading it all in to memory. This flexibility will make it feasible to use the fibers web server to handle requests where the body is of an unknown size, or large enough that you wouldn't want it in memory.

The biggest downside of this change is that it breaks the handler interface as it's just passed a single argument, rather than two, I'm not sure how to mitigate that though.