### PR TITLE
Revert "libevent: gc free wait_data"

### DIFF
--- a/extensions/libevent.c
+++ b/extensions/libevent.c
@@ -66,13 +66,6 @@ free_libevt (void *ptr)
 }
 
 static void
-free_wait_data (void *ptr)
-{
-  struct wait_data *data = ptr;
-  scm_gc_free(data, sizeof (struct wait_data), "wait_data");
-}
-
-static void
 cb_func (evutil_socket_t fd, short what, void *arg)
 #define FUNC_NAME "primitive-event-loop"
 {
@@ -132,7 +125,7 @@ scm_primitive_create_event_base (SCM eventsv)
   data->maxevents = SCM_BYTEVECTOR_LENGTH (eventsv) / sizeof (struct event_data);
 
   return scm_list_2 (scm_from_pointer (libevt, free_libevt),
-                     scm_from_pointer (data, free_wait_data));
+                     scm_from_pointer (data, NULL));
 }
 #undef FUNC_NAME
 


### PR DESCRIPTION
This reverts commit 47fa38f580ccd0a6109ace444657eabc15200a22: there's no need to explicitly free this via a finalizer since it lives in GC-managed heap with references in GC-scanned heap.