### PR TITLE
Speeding up 'make check'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,7 +130,9 @@ TESTS += \
 	tests/concurrent-web-server.scm
 endif
 
-TESTS_ENVIRONMENT=top_srcdir="$(abs_top_srcdir)" ./env $(GUILE) -s
+TESTS_ENVIRONMENT =				\
+  top_srcdir="$(abs_top_srcdir)" ./env		\
+  $(GUILE) --no-auto-compile -s
 
 EXTRA_DIST += \
 	$(bin_SCRIPTS) \

--- a/build-aux/guile.am
+++ b/build-aux/guile.am
@@ -23,6 +23,6 @@ EXTRA_DIST = $(SOURCES) $(NOCOMP_SOURCES)
 GUILE_WARNINGS = -Wunbound-variable -Warity-mismatch -Wformat
 SUFFIXES = .scm .go
 .scm.go:
-	$(AM_V_GEN) $(top_builddir)/env	\
+	$(AM_V_GEN) GUILE_AUTO_COMPILE=0 $(top_builddir)/env		\
 	  $(GUILE_TOOLS) compile $(GUILE_TARGET) -L "$(abs_top_srcdir)"	\
 	  $(GUILE_WARNINGS) -o "$@" "$<"

--- a/guix.scm
+++ b/guix.scm
@@ -45,14 +45,6 @@
                       "texinfo" "gettext-minimal"))))
     (inputs
      (list (S "guile")))
-    (arguments
-     `(#:phases (modify-phases %standard-phases
-                  (add-before 'configure 'bootstrap
-                    (lambda _
-                      (zero? (system* "./autogen.sh"))))
-                  (add-before 'configure 'setenv
-                    (lambda _
-                      (setenv "GUILE_AUTO_COMPILE" "0"))))))
     (synopsis "Lightweight concurrency facility for Guile")
     (description
      "Fibers is a Guile library that implements a a lightweight concurrency

--- a/tests/basic.scm
+++ b/tests/basic.scm
@@ -244,9 +244,17 @@
 (assert-run-fibers-terminates (do-times 100000 (spawn-fiber (lambda () #t))) #:drain? #t)
 (assert-run-fibers-terminates (do-times 100000
                                         (spawn-fiber (lambda () #t) #:parallel? #t)) #:drain? #t)
-(define (loop-to-1e4) (let lp ((i 0)) (when (< i #e1e4) (lp (1+ i)))))
-(assert-run-fibers-terminates (do-times 100000 (spawn-fiber loop-to-1e4)) #:drain? #t)
-(assert-run-fibers-terminates (do-times 100000 (spawn-fiber loop-to-1e4 #:parallel? #t)) #:drain? #t)
+
+(define %long-loop-iterations
+  ;; Number of iterations such that 'loop-long-enough' takes a while (~30s)
+  ;; or current hardware when this file is interpreted.
+  #e1e3)
+
+(define (loop-long-enough)
+  (let lp ((i 0)) (when (< i %long-loop-iterations) (lp (1+ i)))))
+
+(assert-run-fibers-terminates (do-times 100000 (spawn-fiber loop-long-enough)) #:drain? #t)
+(assert-run-fibers-terminates (do-times 100000 (spawn-fiber loop-long-enough #:parallel? #t)) #:drain? #t)
 (assert-run-fibers-terminates (do-times 1 (spawn-fiber (lambda () (sleep 1)))) #:drain? #t)
 (assert-run-fibers-terminates (do-times 10 (spawn-fiber (lambda () (sleep 1)))) #:drain? #t)
 (assert-run-fibers-terminates (do-times 100 (spawn-fiber (lambda () (sleep 1)))) #:drain? #t)

--- a/tests/speedup.scm
+++ b/tests/speedup.scm
@@ -66,15 +66,15 @@ Set the 'FIBERS_EXPENSIVE_TESTS' environment variable to run it.~%")
 (measure-speedup
  (do-times 40000 (spawn-fiber (lambda () (sleep 1)) #:parallel? #t)))
 (measure-speedup
- (do-times 100000 (spawn-fiber (lambda () (loop-to #e1e4)) #:parallel? #t)))
+ (do-times 100000 (spawn-fiber (lambda () (loop-to #e1e3)) #:parallel? #t)))
 (measure-speedup
- (do-times 10000 (spawn-fiber (lambda () (loop-to #e1e5)) #:parallel? #t)))
+ (do-times 10000 (spawn-fiber (lambda () (loop-to #e1e4)) #:parallel? #t)))
 (measure-speedup
- (do-times 1000 (spawn-fiber (lambda () (loop-to #e1e6)) #:parallel? #t)))
+ (do-times 1000 (spawn-fiber (lambda () (loop-to #e1e5)) #:parallel? #t)))
 
 (measure-speedup
- (do-times 100000 (spawn-fiber (lambda () (alloc-to 4 #e1e3)) #:parallel? #t)))
+ (do-times 100000 (spawn-fiber (lambda () (alloc-to 4 #e1e2)) #:parallel? #t)))
 (measure-speedup
- (do-times 10000 (spawn-fiber (lambda () (alloc-to 4 #e1e4)) #:parallel? #t)))
+ (do-times 10000 (spawn-fiber (lambda () (alloc-to 4 #e1e3)) #:parallel? #t)))
 (measure-speedup
- (do-times 1000 (spawn-fiber (lambda () (alloc-to 4 #e1e5)) #:parallel? #t)))
+ (do-times 1000 (spawn-fiber (lambda () (alloc-to 4 #e1e4)) #:parallel? #t)))

--- a/tests/speedup.scm
+++ b/tests/speedup.scm
@@ -53,6 +53,14 @@
         (lp (1+ i) (make-vector (- words 2) #f))
         x)))
 
+(unless (getenv "FIBERS_EXPENSIVE_TESTS")
+  (newline (current-error-port))
+  (format (current-error-port) "Skipping expensive test/benchmark.~%")
+  (format (current-error-port) "\
+Set the 'FIBERS_EXPENSIVE_TESTS' environment variable to run it.~%")
+  (newline (current-error-port))
+  (exit 77))
+
 (measure-speedup
  (do-times 100000 (spawn-fiber (lambda () #t) #:parallel? #t)))
 (measure-speedup


### PR DESCRIPTION
This change ensures `make check` runs in a timely fashion, particularly in Guix build environments.

Why Guix? Because the default `$HOME` in build environments in not writable, meaning that tests were not auto-compiled, and thus `loop-to-1e4` and similar would take *much* longer (especially on low-end AArch64 or RISC-V machines where it would typically time out after an hour).